### PR TITLE
Correct Python dependency tables in AGENTS.md and requirements.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,9 @@ Skills for creating, reading, and manipulating PDF, PPTX, XLSX, and DOCX files.
 | pytesseract | `pytesseract` | pdf | OCR wrapper for Tesseract |
 | pypdfium2 | `pypdfium2` | pdf | PDF rendering using PDFium engine |
 | python-pptx | `python-pptx` | pptx | PowerPoint file manipulation |
-| openpyxl | `openpyxl` | xlsx | Excel file manipulation |
-| pandas | `pandas` | xlsx | Data analysis, table operations |
+| markitdown | `markitdown[pptx]` | pptx | Extract PPTX text as Markdown |
+| openpyxl | `openpyxl` | pdf, xlsx | Excel file manipulation |
+| pandas | `pandas` | pdf, xlsx | Data analysis, table operations |
 | matplotlib | `matplotlib` | xlsx | Chart and visualization creation |
 | lxml | `lxml` | pptx, docx | XML processing and XSD schema validation |
 | defusedxml | `defusedxml` | pptx, docx | Secure XML parsing (XXE protection) |

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ reportlab
 pytesseract
 pdf2image
 pypdfium2
-pillow
+Pillow
 
 # Excel/data analysis
 pandas


### PR DESCRIPTION
Doc-only fixes from auditing the dependency manifests against the skills' actual PEP 723 headers, imports, and SKILL.md references.

## Changes
- **`openpyxl` / `pandas`** — "Used by" corrected to `pdf, xlsx`. Both are used by the **pdf** skill (table extraction / export to Excel: `pdf/tables.md`, `pdf/SKILL.md`), not xlsx-only.
- **`markitdown`** — added a row (`markitdown[pptx]`, used by **pptx**: `pptx/SKILL.md`); it was missing from the table though already present in `requirements.txt`.
- **`requirements.txt`** — `pillow` → `Pillow` to match the casing in the PEP 723 headers.

## Scope / non-goals
- No skill scripts or PEP 723 headers touched; **no versions pinned**.
- The two manifests (the `AGENTS.md` table and `requirements.txt`) now list the same package set.